### PR TITLE
Update menu display after hide on large screens, Add admin via command line, Add page name to url

### DIFF
--- a/src/libs/app.js
+++ b/src/libs/app.js
@@ -1,6 +1,7 @@
 const Common = require('./common.js').Common;
 const WebServer = require('./webserver.js');
 const fs = require('fs');
+let prompt = require('prompt');
 
 class App {
  run() {
@@ -10,8 +11,9 @@ class App {
     this.startServer();
     break;
    case 1:
-    if (args[0] == '--create-settings') this.createSettings();
-    if (args[0] == '--create-database') this.createDatabase();
+    if (args[0] === '--create-settings') this.createSettings();
+    if (args[0] === '--create-database') this.createDatabase();
+    if (args[0] === '--create-admin') this.createAdmin();
     else this.getHelp();
     break;
    default:
@@ -98,6 +100,35 @@ class App {
   const data = new Data();
   data.createDB();
   Common.addLog('Database was created sucessfully.');
+  Common.addLog('');
+ }
+
+createAdmin() {
+  var username = '', password = '';
+  this.loadSettings();
+  const Data = require('./data.js');
+  const data = new Data();
+  var schema = {
+    properties: {
+      username: {
+        pattern: /^[a-zA-Z\s\-]+$/,
+        message: 'Name must be only letters, spaces, or dashes',
+        required: true
+      },
+      password: {
+        hidden: true,
+        required: true
+      }
+    }
+  };
+  prompt.start();
+  prompt.get(schema, function (err, result) {
+    if(err) throw err;
+    username = result.username;
+    password = result.password;
+    data.createAdmin(username, password);
+    Common.addLog('Admin was created sucessfully.');
+  });
   Common.addLog('');
  }
 }

--- a/src/libs/data.js
+++ b/src/libs/data.js
@@ -113,7 +113,7 @@ class Data {
  }
 
  async adminGetAliases(domainID) {
-  if(id === undefined) id = 0; // to help with sql undefined column name
+  if(domainID === undefined) domainID = 0; // to help with sql undefined column name
   return await this.db.read('SELECT id, alias, mail, created FROM aliases WHERE id_domain = $1', [domainID]);
  }
 

--- a/src/libs/data.js
+++ b/src/libs/data.js
@@ -25,6 +25,12 @@ class Data {
    process.exit(1);
   }
  }
+
+ async createAdmin(user, pass) {
+  if(!user && !pass) this.res;
+  return await this.db.write('INSERT INTO admins (user, pass) VALUES ($1, $2)', [user, this.getHash(pass)]);
+ }
+
  res = {
   'error': true,
   'message': 'Missing input fields'
@@ -127,11 +133,6 @@ class Data {
 
  async adminGetAdmins() {
   return await this.db.read('SELECT id, user, created FROM admins', []);
- }
-
- async adminAddAdmin(user, pass) {
-  if(!user && !pass) this.res;
-  return await this.db.write('INSERT INTO admins (user, pass) VALUES ($1, $2)', [user, this.getHash(pass)]);
  }
 
  async adminSetAdmin(id, user, pass) {

--- a/src/libs/webserver.js
+++ b/src/libs/webserver.js
@@ -3,6 +3,7 @@ const https = require('http2');
 const http2express = require('http2-express-bridge');
 const express = require('express');
 const fs = require('fs');
+const path = require('path');
 const WebSocketServer = require('ws').Server;
 const Common = require('./common.js').Common;
 const Protocol = require('./protocol.js');
@@ -25,9 +26,10 @@ class WebServer {
      (function(i) {
         app.use(Common.settings.webs[i].url, express.static(Common.settings.webs[i].path));
         app.get(Common.settings.webs[i].url + '/:page', (req, res) => {
-         console.log(Common.settings.webs[i]); // fixed
+         console.log(Common.settings.webs[i]);
+         // res.sendFile(__dirname + '/' + Common.settings.webs[i].path + '/index.html');
+         path.resolve('/' + Common.settings.webs[i].path + '/index.html')
          res.send('ok');
-       //   res.sendfile(Common.settings.webs[i].path + '/index.html');
         });
      })(i);
     }

--- a/src/package.json
+++ b/src/package.json
@@ -4,6 +4,7 @@
     "express": "*",
     "http2-express-bridge": "*",
     "nodemon": "^2.0.20",
+    "prompt": "^1.3.0",
     "sqlite": "*",
     "sqlite3": "*",
     "ws": "*"

--- a/src/www/webadmin/js/functions.js
+++ b/src/www/webadmin/js/functions.js
@@ -20,24 +20,43 @@ async function getPage(name) {
  if (document.querySelectorAll('.active').length >= 1) document.querySelectorAll('.active')[0].classList.remove('active');
  document.querySelector('#menu-' + name).classList.add('active');
  document.querySelector('#content').innerHTML = await getFileContent('html/' + name + '.html');
- if (name == 'stats') getStats();
- if (name == 'domains') getDomains();
- if (name == 'users') getUsers();
- if (name == 'aliases') getAliases();
- if (name == 'admins') getAdmins();
+ if (name == 'stats') {
+   window.history.replaceState(null, null, "/webadmin/stats");
+   getStats();
+ }
+ if (name == 'domains') {
+   window.history.replaceState(null, null, "/webadmin/domains");
+   getDomains();
+ }
+ if (name == 'users') {
+   window.history.replaceState(null, null, "/webadmin/users");
+   getUsers();
+ }
+ if (name == 'aliases') {
+   window.history.replaceState(null, null, "/webadmin/aliases");
+   getAliases();
+ }
+ if (name == 'admins') {
+   window.history.replaceState(null, null, "/webadmin/admins");
+   getAdmins();
+ }
  menuHide();
 }
 
 function menuShowHide() {
- if (window.matchMedia('(max-width: 1000px)').matches) {
-  var menu = document.querySelector('#page #menu');
-  menu.style.display = menu.style.display == 'none' ? 'block' : 'none';
- }
+   if (window.matchMedia('(max-width: 1000px)').matches) {
+    var menu = document.querySelector('#page #menu');
+    menu.style.display = menu.style.display === 'none' ? 'block' : 'none';
+   }
 }
 
 function menuHide() {
  if (window.matchMedia('(max-width: 1000px)').matches) document.querySelector('#page #menu').style.display = 'none';
 }
+window.addEventListener("resize", function(event) {
+   if (window.matchMedia('(max-width: 1000px)').matches) document.querySelector('#page #menu').style.display = 'none';
+   else document.querySelector('#page #menu').style.display = 'block';
+});
 
 function login() {
  wsSend({


### PR DESCRIPTION
#### what does this pr do?
Enable adding an admin via the terminal using command flag ('--create-admin')
Show page name to url after '/webadmin'
Redisplay the menu after hiding and enlarging the viewport width.

#### how can this be manually tested?
Run start server command, but with '--create-admin' flag, enter credentials to create new admin
Open '/webadmin', click on any page to view url.
Hide menu on small screen (maybe test using dev tools horizontal display), then enlarge scren (maybe by closing the dev tools). Menu automatically redisplays, as opposed to before when it would remian hidden
