### PR TITLE
feat: add/ edit/ delete admin from web, resize footer, init url state

### DIFF
--- a/src/libs/app.js
+++ b/src/libs/app.js
@@ -126,7 +126,7 @@ createAdmin() {
     if(err) throw err;
     username = result.username;
     password = result.password;
-    data.createAdmin(username, password);
+    data.adminAddAdmin(username, password);
     Common.addLog('Admin was created sucessfully.');
   });
   Common.addLog('');

--- a/src/libs/data.js
+++ b/src/libs/data.js
@@ -26,11 +26,6 @@ class Data {
   }
  }
 
- async createAdmin(user, pass) {
-  if(!user && !pass) this.res;
-  return await this.db.write('INSERT INTO admins (user, pass) VALUES ($1, $2)', [user, this.getHash(pass)]);
- }
-
  res = {
   'error': true,
   'message': 'Missing input fields'
@@ -50,7 +45,7 @@ class Data {
 
  async adminGetTokenExists(token) {
   var res = await this.db.read('SELECT id FROM admins_login WHERE token = $1', [token]);
-  return res.length == 1 ? true : false;
+  return res.length === 1 ? true : false;
  }
 
  async adminIsTokenValid(token) {
@@ -94,7 +89,7 @@ class Data {
  }
 
  async adminGetUsers(id) {
-  if(id === undefined) id = 0; // to help with sql undefined column name
+  if(id === undefined) return [];
   return await this.db.read('SELECT id, name, visible_name, photo, created FROM users WHERE id_domain = $1', [id]);
  }
 
@@ -113,7 +108,7 @@ class Data {
  }
 
  async adminGetAliases(domainID) {
-  if(domainID === undefined) domainID = 0; // to help with sql undefined column name
+  if(domainID === undefined) return [];
   return await this.db.read('SELECT id, alias, mail, created FROM aliases WHERE id_domain = $1', [domainID]);
  }
 
@@ -123,7 +118,7 @@ class Data {
  }
 
  async adminSetAlias(id, alias, mail) {
-  if(!domainID && !alias && !mail) return this.res;
+  if(!id && !alias && !mail) return this.res;
   return await this.db.write('UPDATE aliases SET alias = $1, mail = $2 WHERE id = $3', [alias, mail, id]);
  }
 
@@ -135,12 +130,17 @@ class Data {
   return await this.db.read('SELECT id, user, created FROM admins', []);
  }
 
+ async adminAddAdmin(user, pass) {
+  if(!user && !pass) this.res;
+  return await this.db.write('INSERT INTO admins (user, pass) VALUES ($1, $2)', [user, this.getHash(pass)]);
+ }
+
  async adminSetAdmin(id, user, pass) {
-  return await this.db.write('UPDATE admins SET name = $1 WHERE id = $2', [user, pass != '' ? ', pass = "' + pass + '"' : '']);
+  return await this.db.write('UPDATE admins SET user = $1, pass = $2 WHERE id = $3', [user, pass != '' ? ', pass = "' + pass + '"' : '', id]);
  }
 
  async adminDelAdmin(id) {
-  return await this.db.write('DELETE FROM admin WHERE id = $1', [id]);
+  return await this.db.write('DELETE FROM admins WHERE id = $1', [id]);
  }
 
  getToken(len) {

--- a/src/libs/database.js
+++ b/src/libs/database.js
@@ -15,7 +15,9 @@ class Database {
   try {
    await this.open();
    var res = await this.db.all(query, params, (err, success) => {
-    if(err) throw new Error(err) && Common.addLog(err);
+    console.log('err ====> ', err);
+    console.log('success ====> ', success);
+    if(err) throw new Error(err) && Common.addLog('read err ====> ', err);
    });
    this.close();
    return res;
@@ -28,7 +30,7 @@ class Database {
   try {
    await this.open();
    await this.db.run(query, params, (err, success) => {
-    if(err) throw new Error(err) && Common.addLog(err);
+    if(err) throw new Error(err) && Common.addLog('write err ====> ', err);
    });
    this.close();
   } catch (ex) {

--- a/src/libs/protocol.js
+++ b/src/libs/protocol.js
@@ -9,14 +9,19 @@ class Protocol {
  }
 
  async protocolHandler(data) {
-  var req = JSON.parse(data);
-  var res = {}
-  if (req.command) {
-   if (req.command.startsWith('admin_')) res = await this.processAdminCommand(req);
-   else if (req.command.startsWith('user_')) res = await this.processUserCommand(req);
-   else res = { error: 'command_unknown', message: 'Command is unknown' }
-  } else res = { error: 'command_missing', message: 'Command was not specified' }
-  return JSON.stringify(res);
+   try {
+    console.log(data);
+    var req = JSON.parse(data);
+    var res = {}
+    if (req.command) {
+    if (req.command.startsWith('admin_')) res = await this.processAdminCommand(req);
+    else if (req.command.startsWith('user_')) res = await this.processUserCommand(req);
+    else res = { error: 'command_unknown', message: 'Command is unknown' }
+    } else res = { error: 'command_missing', message: 'Command was not specified' }
+    return JSON.stringify(res);
+   } catch (error) {
+      return JSON.stringify({ error: 'invalid command', message: 'expected valid json', "error": error.message })
+   }
  }
 
  async processAdminCommand(req) {
@@ -43,7 +48,7 @@ class Protocol {
     else if (req.command == 'admin_set_aliases') return { command: req.command, data: await this.data.adminSetAlias(req.id, req.alias, req.mail) };
     else if (req.command == 'admin_del_aliases') return { command: req.command, data: await this.data.adminDelAlias(req.id) };
     else if (req.command == 'admin_get_admins') return { command: req.command, data: await this.data.adminGetAdmins() };
-    else if (req.command == 'admin_add_admin') return { command: req.command, data: await this.data.adminAddAdmin(req.name) };
+    else if (req.command == 'admin_add_admin') return { command: req.command, data: await this.data.adminAddAdmin(req.name, req.pass) };
     else if (req.command == 'admin_set_admin') return { command: req.command, data: await this.data.adminSetAdmin(req.id, req.name) };
     else if (req.command == 'admin_del_admin') return { command: req.command, data: await this.data.adminDelAdmin(req.id) };
     else if (req.command == 'admin_sysinfo') return { command: req.command, data: this.getSysInfo() };

--- a/src/libs/webserver.js
+++ b/src/libs/webserver.js
@@ -27,14 +27,13 @@ class WebServer {
         app.use(Common.settings.webs[i].url, express.static(Common.settings.webs[i].path));
         app.get(Common.settings.webs[i].url + '/:page', (req, res) => {
          console.log(Common.settings.webs[i]);
-         // res.sendFile(__dirname + '/' + Common.settings.webs[i].path + '/index.html');
-         path.resolve('/' + Common.settings.webs[i].path + '/index.html')
-         res.send('ok');
+         res.sendFile(path.join(__dirname, '../www' + Common.settings.webs[i].url + '/index.html'));
+         // res.send('ok');
         });
      })(i);
     }
    }
-   app.use('*', express.static(Common.settings.web_notfound_path));
+   // app.use('*', (d) => { console.log('custom d is ---> ', d) }, express.static(Common.settings.web_notfound_path));
    this.httpServer = http.createServer(app).listen(Common.settings.http_port);
    Common.addLog('HTTP server running on port: ' + Common.settings.http_port);
    this.httpsServer = https.createSecureServer({ key: fs.readFileSync(cert_priv), cert: fs.readFileSync(cert_pub), ca: fs.readFileSync(cert_chain), allowHTTP1: true }, app).listen(Common.settings.https_port);

--- a/src/www/webadmin/css/style.css
+++ b/src/www/webadmin/css/style.css
@@ -313,9 +313,15 @@ table tbody tr td, table thead tr th {
  padding: 10px;
 }
 
+#footer-container {
+    width: 100%;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    z-index: 100;
+}
+
 #footer {
- z-index: 100;
- position: absolute;
  display: flex;
  align-items: center;
  bottom: 1px;

--- a/src/www/webadmin/html/admin_add.html
+++ b/src/www/webadmin/html/admin_add.html
@@ -1,0 +1,8 @@
+<div>
+    <input id="admin_name" type="text" placeholder="Admin Name"/>
+    <input id="admin_pass" type="password" placeholder="Admin password" />
+</div>
+<div>
+ <a class="button" onclick="adminAdd()">Add</a>
+ <a class="button" onclick="dialogClose()">Cancel</a>
+</div>

--- a/src/www/webadmin/html/admin_delete.html
+++ b/src/www/webadmin/html/admin_delete.html
@@ -1,0 +1,7 @@
+<div>
+    <br/><br/>
+</div>
+<div>
+ <a class="button" onclick="delAdmin()">Confirm</a>
+ <a class="button" onclick="dialogClose()">Cancel</a>
+</div>

--- a/src/www/webadmin/html/admin_update.html
+++ b/src/www/webadmin/html/admin_update.html
@@ -1,0 +1,8 @@
+<div>
+    <input id="updated_admin_name" type="text" placeholder="Admin Name"/>
+    <input id="updated_admin_pass" type="password" placeholder="Admin password" />
+</div>
+<div>
+ <a class="button" onclick="adminUpdate()">Update</a>
+ <a class="button" onclick="dialogClose()">Cancel</a>
+</div>

--- a/src/www/webadmin/html/admins_row.html
+++ b/src/www/webadmin/html/admins_row.html
@@ -2,6 +2,6 @@
  <td>{USER}</td>
  <td>{CREATED}</td>
  <td>
-  <a class="button" onclick="editAdmin({ID})">Edit</a>
-  <a class="button" onclick="delAdmin({ID})">Delete</a>
+  <a class="button" onclick="editAdmin({ID}, `{USER}`)">Edit</a>
+  <a class="button" onclick="delAdminDialog({ID})">Delete</a>
  </td></tr>

--- a/src/www/webadmin/index.html
+++ b/src/www/webadmin/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">  <!-- to update later with translations -->
  <head>
   <title>New Mail server administration</title>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -10,11 +10,13 @@
  </head>
  <body>
   <div id="page"></div>
-  <div id="footer">
-   <div class="icon offline"></div>
-   <div class="status">Not connected, reconnecting ...</div>
-   <div>Server:</div>
-   <div class="address"></div>
+  <div id="footer-container">
+    <div id="footer">
+     <div class="icon offline"></div>
+     <div class="status">Not connected, reconnecting ...</div>
+     <div>Server:</div>
+     <div class="address"></div>
+    </div>
   </div>
  </body>
 </html>


### PR DESCRIPTION
#### what does this pr do?
Align footer on center (large screens)
Add, update and delete an admin from '/webadmin' > 'admins' tab


Initialize the url state management

#### further eading
The url works, but does not display data on inital load (after receiving handshake).
Also, the loading of domain IDs seems to have been broken (on the select menu on users and aliases tabs).
Will work on this by next commit. 