### PR TITLE
feat: disable  root admin deletion, add user message count

### DIFF
--- a/src/libs/app.js
+++ b/src/libs/app.js
@@ -111,8 +111,8 @@ createAdmin() {
   var schema = {
     properties: {
       username: {
-        pattern: /^[a-zA-Z\s\-]+$/,
-        message: 'Name must be only letters, spaces, or dashes',
+        pattern: /^[a-zA-Z\-.]+$/,
+        message: 'Name must be only letters, dots or dashes',
         required: true
       },
       password: {

--- a/src/libs/data.js
+++ b/src/libs/data.js
@@ -90,7 +90,9 @@ class Data {
 
  async adminGetUsers(id) {
   if(id === undefined) return [];
-  return await this.db.read('SELECT id, name, visible_name, photo, created FROM users WHERE id_domain = $1', [id]);
+  return await this.db.read(
+    `SELECT users.id, users.name, users.visible_name, users.photo, users.created, COUNT(messages.id) AS message_count
+    FROM users LEFT JOIN messages ON messages.id_user = users.id WHERE users.id_domain = $1 GROUP BY users.id;`, [id]);
  }
 
  async adminAddUser(domainID, name, visibleName, pass) {
@@ -140,6 +142,10 @@ class Data {
  }
 
  async adminDelAdmin(id) {
+  if(id === 1) return {
+    error: true,
+    message: "cannot remove root admin"
+  }
   return await this.db.write('DELETE FROM admins WHERE id = $1', [id]);
  }
 

--- a/src/libs/webserver.js
+++ b/src/libs/webserver.js
@@ -52,7 +52,7 @@ class WebServer {
   ws.onmessage = async (data) => { this.wsOnMessage(ws, data) };
   ws.onclose = () => { this.wsOnClose(); };
   ws.onerror = () => { Common.addLog('WEBSOCKET - CLIENT ERROR'); }
-  this.wsSend(ws, 'HANDSHAKE FROM SERVER');
+  this.wsSend(ws, JSON.stringify({message: 'HANDSHAKE FROM SERVER', handshake: true}));
  }
 
  async wsOnMessage(ws, e) {

--- a/src/www/webadmin/js/functions.js
+++ b/src/www/webadmin/js/functions.js
@@ -48,7 +48,6 @@ async function getPage(name) {
    getStats();
  }
  if (name === 'domains') {
-   console.log('get domains method should be below, but why not?');
    getDomains();
    replaceWindowState("/webadmin/domains");
  }
@@ -446,7 +445,6 @@ async function wsOnMessage(data) {
   if (data.command == 'admin_sysinfo') setSysInfo(data);
   if (data.command == 'admin_get_domains') {
    for(let i = 0; i < data.data.length; i++) {
-      console.log(data.data[i]);
       domainsData.push(data.data[i].id);
    }
    setOptions();
@@ -462,7 +460,6 @@ async function wsOnMessage(data) {
    else await getDialog('Delete domain', 'Removed successfully');
   }
   if (data.command == 'admin_add_domain') {
-   console.log(data);
    if(data.data !== undefined && data.data.error) await getDialog('Add domain Error', data.data.message);
    else await getDialog('Add domain', 'Added successfully');
   }
@@ -591,7 +588,6 @@ async function setUsers(res) {
  var rows = '';
  var rowTemp = await getFileContent('html/users_row.html');
  if(res.data.length > 0) {
-  console.log('res -> ', res)
   for (var i = 0; i < res.data.length; i++) {
    rows += translate(rowTemp, {
     '{ID}': res.data[i].id,
@@ -608,7 +604,6 @@ async function setUsers(res) {
 }
 
 async function setAliases(res) {
-console.log(res);
  document.querySelector('#aliases').innerHTML = '<br/>&emsp;Checking...<br/><br/>';
  var rows = '';
  var rowTemp = await getFileContent('html/aliases_row.html');

--- a/src/www/webadmin/js/functions.js
+++ b/src/www/webadmin/js/functions.js
@@ -10,18 +10,32 @@ let idData = {
 window.onload = async function() {
  wsConnect(server);
  let page_ = '';
-//  await getDomains();
- console.log(domainsData);
  var login = localStorage.getItem('admin_token') ? false : true;
  if(window.location.pathname.split('webadmin/')[1]) page_ = window.location.pathname.split('webadmin/')[1]
  else page_ = 'stats';
  document.querySelector('#page').innerHTML = await getFileContent('html/' + (login ? 'login' : 'home') + '.html');
+ replaceWindowState('/webadmin/' + page_);
  if (login) document.querySelector('#user').focus();
- else await getPage(page_);
+ else getPage(page_);
 }
 
 function replaceWindowState(url) {
    return window.history.replaceState(null, null, url);
+}
+
+setTimeout(() => {
+   getDomains();
+}, time);
+
+function setOptions() {
+ let domainsSelect = document.querySelector('#select_domains');
+ for (let i = 0; i < domainsData.length; i++) {
+  let option = document.createElement('option');
+  option.value = domainsData[i];
+  option.innerHTML = domainsData[i];
+  if(domainsSelect.children.length - 1 === domainsData.length) break;
+  domainsSelect.append(option);   
+ }
 }
 
 async function getPage(name) {
@@ -34,8 +48,9 @@ async function getPage(name) {
    getStats();
  }
  if (name === 'domains') {
-   replaceWindowState("/webadmin/domains");
+   console.log('get domains method should be below, but why not?');
    getDomains();
+   replaceWindowState("/webadmin/domains");
  }
  if (name === 'users') {
    replaceWindowState("/webadmin/users");
@@ -49,6 +64,7 @@ async function getPage(name) {
    replaceWindowState("/webadmin/admins");
    getAdmins();
  }
+ setOptions();
  menuHide();
 }
 
@@ -424,14 +440,16 @@ async function wsOnMessage(data) {
  if ('error' in data) {
   if (data.error == 'admin_token_invalid') logout();
  } else {
+  if(data.handshake) getDomains();
   if (data.command == 'admin_login') setAdminLogin(data);
   if (data.command == 'admin_logout') setAdminLogout(data);
   if (data.command == 'admin_sysinfo') setSysInfo(data);
   if (data.command == 'admin_get_domains') {
-   if(data.data.length > 0)
-    data.data.forEach((item) => {
-        domainsData.push(item.id)
-    });
+   for(let i = 0; i < data.data.length; i++) {
+      console.log(data.data[i]);
+      domainsData.push(data.data[i].id);
+   }
+   setOptions();
    if (page === 'domains') setDomains(data);
    if (page === 'users') setUsersDomains(data);
    if (page === 'aliases') setAliasesDomains(data);
@@ -474,7 +492,10 @@ async function wsOnMessage(data) {
    else await getDialog('Update Admin', 'Updated successfully');
   }
   if (data.command == 'admin_del_aliases') await getDialog('Delete Alias', 'Deleted successfully');
-  if (data.command == 'admin_del_admin') await getDialog('Delete Admin', 'Deleted successfully');
+  if (data.command == 'admin_del_admin') {
+   if(data.data !== undefined && data.data.error) await getDialog('Delete admin Error', data.data.message);
+   else await getDialog('Deleted Admin', 'Deleted successfully');
+  }
  }
 }
 
@@ -529,7 +550,6 @@ async function setDomains(res) {
  document.querySelector('#domains').innerHTML = '<br/>&emsp;Checking...<br/><br/>';
  var rows = '';
  var rowTemp = await getFileContent('html/domains_row.html');
- domainsData = [...new Set(domainsData)]
  if(res.data.length > 0) {
   for (var i = 0; i < res.data.length; i++) {
     rows += translate(rowTemp, {
@@ -551,7 +571,7 @@ async function setUsersDomains(res) {
    '{NAME}': res.data[i].name
   });
  }
- document.querySelector('#domains').innerHTML = rows;
+ if(document.querySelector('#domains')) document.querySelector('#domains').innerHTML = rows;
 }
 
 async function setAliasesDomains(res) {
@@ -570,22 +590,15 @@ async function setUsers(res) {
  document.querySelector('#users').innerHTML = '<br/>&emsp;Checking...<br/><br/>';
  var rows = '';
  var rowTemp = await getFileContent('html/users_row.html');
- let domainsSelect = document.querySelector('#select_domains');
- for(let i = 0; i < domainsData.length; i++) {
-  let option = document.createElement('option');
-  option.value = domainsData[i];
-  option.innerHTML = domainsData[i];
-  if(domainsSelect.children.length - 1 === domainsData.length) break;
-  domainsSelect.append(option);
- }
  if(res.data.length > 0) {
+  console.log('res -> ', res)
   for (var i = 0; i < res.data.length; i++) {
    rows += translate(rowTemp, {
     '{ID}': res.data[i].id,
     '{NAME}': res.data[i].name,
     '{VISIBLE_NAME}': res.data[i].visible_name,
     '{PHOTO}': res.data[i].photo,
-    '{MESSAGES}': '?',
+    '{MESSAGES}': res.data[i].message_count,
     '{FILES_SIZE}': '?',
     '{CREATED}': new Date(res.data[i].created).toLocaleString()
    });
@@ -600,13 +613,6 @@ console.log(res);
  var rows = '';
  var rowTemp = await getFileContent('html/aliases_row.html');
  let domainsSelect = document.querySelector('#select_domains');
- for(let i = 0; i < domainsData.length; i++) {
-  let option = document.createElement('option');
-  option.value = domainsData[i];
-  option.innerHTML = domainsData[i];
-  if(domainsSelect.children.length - 1 === domainsData.length) break;
-  domainsSelect.append(option);
- }
  if(res.data.length > 0) {
     for (var i = 0; i < res.data.length; i++) {
      rows += translate (rowTemp, {


### PR DESCRIPTION
### what does this pr do?
Enable admins to see user message count on '/webadmin'
Disable deletion of root admin account (admin_id = 1)

### How can this be manually tested?
- Navigate to '/webadmin/admins' and try deleting the first admin
- Naviagate to '/webadmin/users' and check "messages" column